### PR TITLE
Create workflow for publishing to pypi-test

### DIFF
--- a/.github/workflows/publish-pypi-test.yml
+++ b/.github/workflows/publish-pypi-test.yml
@@ -1,0 +1,41 @@
+# .github/workflows/publish-pypi-test.yaml
+# uses trusted publishing to publish the package to test-pypi as described here:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
+
+      - name: Install uv 🌟
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ">=0.0.1"
+
+      - name: Build package for distribution 🛠️
+        run: |
+          uv build
+
+      - name: Upload distribution packages 📤
+        uses: actions/upload-artifact@v4
+        with:
+          name: cladetime-package-distribution
+          path: dist/
+
+# TODO: add a job for publishing to test-pypi


### PR DESCRIPTION
This commit adds the beginning of a workflow for automated publishing to pypi-test. The only job in the workflow right now is the build job.