### PR TITLE
Make sure checkout also fetches tags

### DIFF
--- a/.github/workflows/publish-pypi-test.yml
+++ b/.github/workflows/publish-pypi-test.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python 🐍


### PR DESCRIPTION
Hopefully this change will ensure that setuptools-scm generates the correct version by ensuring that the checkout action includes all tags.